### PR TITLE
🐛 FIX: Background image/video position issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,16 +24,6 @@ To better manage ACF Field Groups, the plugin supports [synchronized JSON](https
 
 👉 Please visit the [WDS ACF Blocks Wiki](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks) to learn more about the [features of the blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#block-features) and how you can [create Gutenberg Blocks with ACF](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#creating-gutenberg-blocks-with-acf).
 
-## 📚 Developer Documentation
-
-Please find extensive developer documentation at the following links:
-
-- [WDS ACF Blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks)
-- [Block Features](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#block-features)
-- [Block Details](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#block-details)
-- [How to create Gutenberg Blocks with ACF](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#creating-gutenberg-blocks-with-acf)
-- [Saving and Loading Blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/Saving-and-Loading-Blocks)
-
 ## 📝 Requirements
 
 -   [Node LTS](https://nodejs.org/en/)
@@ -107,6 +97,16 @@ composer run lint
 ```
 
 👉 **Important:** This plugin uses [@wordpress/scripts](https://www.npmjs.com/package/@wordpress/scripts) to lint and compile JavaScript and SCSS.
+
+## 📚 Developer Documentation
+
+Please find extensive developer documentation at the following links:
+
+- [WDS ACF Blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks)
+- [Block Features](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#block-features)
+- [Block Details](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#block-details)
+- [How to create Gutenberg Blocks with ACF](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks#creating-gutenberg-blocks-with-acf)
+- [Saving and Loading Blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/Saving-and-Loading-Blocks)
 
 ## :octocat: Contributing and Support
 

--- a/src/scss/modules/_global.scss
+++ b/src/scss/modules/_global.scss
@@ -41,6 +41,7 @@
 
 	// Z-index container in ACF blocks.
 	.container {
+		position: relative;
 		z-index: 3;
 	}
 

--- a/src/scss/utilities/structure/_layout.scss
+++ b/src/scss/utilities/structure/_layout.scss
@@ -45,6 +45,7 @@ html {
 
 	// Z-index container in ACF blocks.
 	.container {
+		position: relative;
 		z-index: 3;
 	}
 
@@ -73,7 +74,7 @@ html {
 
 	display: block;
 	transform: translateY(-50%);
-	z-index: -1;
+	z-index: 0;
 
 	@supports (object-fit: cover) {
 


### PR DESCRIPTION
Closes #4 

### DESCRIPTION ###
This PR fixes the background image/video position issues in the blocks when the overlay is turned off. It also moves the position of the _Developer Documentation_ section to a better location in the ReadMe.md file.

### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?
