### PR TITLE
Fix/#18 dependency issue

### DIFF
--- a/inc/hooks.php
+++ b/inc/hooks.php
@@ -416,3 +416,33 @@ function wds_acf_blocks_get_the_content( $content ) {
 	return $content;
 }
 add_filter( 'the_content', 'wds_acf_blocks_get_the_content', 20 );
+
+/**
+ * Dependency check to show warning to run `npm install`
+ * before using the plugin.
+ *
+ * @author Ashar Irfan <ashar.irfan@webdevstudios.com>
+ * @since 1.0.0
+ *
+ * @return void Bail early if the asset dependency file does not exist.
+ */
+function wds_acf_blocks_dependency_check() {
+	$asset_file = plugin_dir_path( dirname( __FILE__ ) ) . 'build/index.asset.php';
+
+	if ( file_exists( $asset_file ) ) {
+		return;
+	}
+	?>
+	<div class="notice notice-error">
+		<p>
+			<?php
+			esc_html_e(
+				'Whoops! You need to run `npm install` in the terminal for the WDS ACF Blocks plugin to work first.',
+				'wds-acf-blocks'
+			);
+			?>
+		</p>
+	</div>
+	<?php
+}
+add_action( 'admin_notices', 'wds_acf_blocks_dependency_check' );

--- a/inc/scripts.php
+++ b/inc/scripts.php
@@ -15,11 +15,19 @@ define( 'WDS_ACF_VERSION', '1.0.0' );
  *
  * @author Corey Collins
  * @since 1.0
+ *
+ * @return void Bail early if the asset dependency file does not exist.
  */
 function wds_acf_enqueue_gutenberg_block_scripts() {
 
 	// Autoload dependencies and version.
-	$asset_file = require plugin_dir_path( dirname( __FILE__ ) ) . 'build/index.asset.php';
+	$asset_file_path = plugin_dir_path( dirname( __FILE__ ) ) . 'build/index.asset.php';
+
+	if ( ! file_exists( $asset_file_path ) ) {
+		return;
+	}
+
+	$asset_file = require $asset_file_path;
 
 	wp_register_script(
 		'wds-acf-block-js',


### PR DESCRIPTION
Closes #18 

### DESCRIPTION ###
This PR fixes the white screen of death that pops up due to a non-existing asset dependency file. And displays a warning notice to remind the user to run `npm install` command before using the plugin.

### SCREENSHOTS ###
![screenshot](https://i.imgur.com/qucRdLj.jpg)

### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?

### STEPS TO VERIFY ###
Just clone and activate the plugin with running any commands in the terminal.
