### PR TITLE
📖 DOC: Saving ACF JSON files section

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,14 @@ Click on the edit (✏️) icon that is appearing in the toolbar of the block to
 
 ## 📚 Developer Documentation
 
+### → Saving ACF JSON Files
+
+By default, saving the ACF blocks to JSON files filter is commented out in the plugin. You can enable this feature by removing the comments from this line: https://github.com/WebDevStudios/wds-acf-blocks/blob/main/inc/hooks.php#L27
+
+To know more about loading and saving of blocks in ACF JSON files, visit the [Saving and Loading Blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/Saving-and-Loading-Blocks) section in the Wiki.
+
+### → Important Wiki Links
+
 Please find extensive developer documentation at the following links:
 
 - [WDS ACF Blocks](https://github.com/WebDevStudios/wds-acf-blocks/wiki/WDS-ACF-Blocks)


### PR DESCRIPTION
Closes #24 

### DESCRIPTION ###
This PR adds the _Saving ACF JSON Files_ section to the README.md file of the plugin.

### SCREENSHOTS ###
![screenshot](https://i.imgur.com/2z9lJan.jpg)

### OTHER ###
- [ ] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [ ] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [ ] Does this pass CBT?
