### PR TITLE
Create and assign a WDS category to ACF Blocks

### DIFF
--- a/inc/helpers/register-block-category.php
+++ b/inc/helpers/register-block-category.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Registers a 'WDS' block category with Gutenberg.
+ *
+ * @package abs
+ */
+
+add_filter(
+	'block_categories_all',
+	function( $categories ) {
+
+		// Adding a new category.
+		$categories[] = array(
+			'slug'  => 'WDS',
+			'title' => 'WebDevStudios Blocks',
+		);
+
+		return $categories;
+	}
+);

--- a/src/blocks/accordion/block.json
+++ b/src/blocks/accordion/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "table-row-before",
 	"apiVersion": 2,
 	"keywords": [ "accordion", "block" ],

--- a/src/blocks/cards-repeater/block.json
+++ b/src/blocks/cards-repeater/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "images-alt",
 	"apiVersion": 2,
 	"keywords": [ "cards", "block" ],

--- a/src/blocks/carousel/block.json
+++ b/src/blocks/carousel/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "slides",
 	"apiVersion": 2,
 	"keywords": [ "carousel", "block" ],

--- a/src/blocks/logo-grid/block.json
+++ b/src/blocks/logo-grid/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "grid-view",
 	"apiVersion": 2,
 	"keywords": [ "logo grid", "block" ],

--- a/src/blocks/quotes/block.json
+++ b/src/blocks/quotes/block.json
@@ -4,7 +4,7 @@
 	"description": "A block used to show quotes.",
 	"editorStyle": "file:./editor.css",
 	"editorScript": "file:./editor.js",
-	"category": "abs",
+	"category": "WDS",
 	"icon": "format-quote",
 	"apiVersion": 2,
 	"keywords": [ "quotes", "block" ],

--- a/src/blocks/side-by-side/block.json
+++ b/src/blocks/side-by-side/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "columns",
 	"apiVersion": 2,
 	"keywords": [ "side by side", "block" ],

--- a/src/blocks/tabs/block.json
+++ b/src/blocks/tabs/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "open-folder",
 	"apiVersion": 2,
 	"keywords": [ "tabs", "block" ],

--- a/wpcli/block-starter/block.json
+++ b/wpcli/block-starter/block.json
@@ -6,7 +6,7 @@
 	"editorScript": "file:./editor.js",
 	"style": "file:./style-script.css",
 	"script": "file:./script.js",
-	"category": "theme",
+	"category": "WDS",
 	"icon": "{{icon}}",
 	"apiVersion": 2,
 	"keywords": [ "{{name}}", "block" ],


### PR DESCRIPTION
Closes #WENG-233

### DESCRIPTION ###
- Adds a WDS category for our ACF Blocks
- Assigns the WDS category to the included blocks

### SCREENSHOTS ###
![image](https://user-images.githubusercontent.com/18194487/194102244-cdefc565-1459-4c08-8555-37fea4a8e4c6.png)

### STEPS TO VERIFY ###
* Pull the branch
* Go to a page or post to add a block
* Click the blue +
* Scroll to the bottom
* Verify that all the ACF blocks are using the WebDevStudios category