### PR TITLE
Defines which core blocks are allowed when using the plugin

### DIFF
--- a/inc/helpers/allowed-blocks.php
+++ b/inc/helpers/allowed-blocks.php
@@ -18,6 +18,7 @@ namespace WebDevStudios\abs;
  */
 function allowed_blocks( $abs_allowed_blocks ) {
 
+	// This is meant to overwrite the default set of allowed blocks.
 	$abs_allowed_blocks = [
 		'core/heading',
 		'core/paragraph',

--- a/inc/helpers/allowed-blocks.php
+++ b/inc/helpers/allowed-blocks.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Specify which blocks are allowed.
+ *
+ * @package ABS
+ */
+
+namespace WebDevStudios\abs;
+
+/**
+ * Specify which blocks are allowed.
+ *
+ * @author WebDevStudios
+ *
+ * @param array $abs_allowed_blocks Current list of allowed blocks.
+ *
+ * @return array Allowed block types.
+ */
+function allowed_blocks( $abs_allowed_blocks ) {
+
+	$abs_allowed_blocks = [
+		'core/heading',
+		'core/paragraph',
+		'core/columns',
+		'core/freeform',
+		'core/gallery',
+		'core/html',
+		'core/image',
+		'core/list',
+		'core/separator',
+		'core/spacer',
+		'core/table',
+	];
+
+	// Add ACF blocks.
+	$abs_acf_blocks = acf_get_block_types();
+
+	foreach ( array_keys( $abs_acf_blocks ) as $abs_block_name ) :
+		$abs_allowed_blocks[] = $abs_block_name;
+	endforeach;
+
+	return $abs_allowed_blocks;
+}
+
+// Filter changed at WordPress 5.8.
+// See https://developer.wordpress.org/block-editor/reference-guides/filters/block-filters/#allowed_block_types_all .
+$abs_block_filter_name = 'allowed_block_types_all';
+
+add_filter( $abs_block_filter_name, __NAMESPACE__ . '\allowed_blocks', 99 );


### PR DESCRIPTION
Closes #WENG-233

### DESCRIPTION ###
- Added a filter that allows you to define which core blocks are allowed and then passes them through; anything not in the defined list of core blocks are not allowed
- Allows all blocks registered with ACF

### SCREENSHOTS ###
Note the absence of the core 'Pullquote' block:
![image](https://user-images.githubusercontent.com/18194487/194103948-188690ba-ac2e-4df7-9815-8d5542989d82.png)

### STEPS TO VERIFY ###
* Pull the branch to your local
* Open a page and click the blue + to add a block
* Note that only blocks specified in `allowed-blocks.php` are available to add
