### PR TITLE
Adds `print_block()` function and the ability to pass values to the function from a template part

### DIFF
--- a/inc/helpers/print-block.php
+++ b/inc/helpers/print-block.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Render a block.
+ *
+ * To be used from a template part to render a block.
+ *
+ * @package abs
+ */
+
+namespace WebDevStudios\abs;
+
+/**
+ * Example Usage in a template part in wd_s or another theme.
+ *
+ * Top of file:
+ * use function WebDevStudios\abs\print_block;
+ *
+ * Prints a Call to Action Block.
+ * if ( function_exists( 'WebDevStudios\abs\print_block' ) ) :
+ *  print_block(
+ *      'call-to-action',
+ *      [
+ *          'allowed_innerblocks' => [],
+ *          'fields'              => [
+ *              'eyebrow'     => 'CTA Eyebrow text',
+ *              'heading'     => 'CTA Heading text',
+ *              'content'     => '<p>Lorem ipsum dolor sit amet.</p>',
+ *              'button_args' => [
+ *                  'button' => [
+ *                      'title'  => 'CTA Button Text',
+ *                      'url'    => 'https://webdevstudios.com',
+ *                      'target' => '',
+ *                  ],
+ *              ],
+ *              'layout'      => 'center',
+ *          ],
+ *      ]
+ *  );
+ * endif;
+ */
+
+
+/**
+ * Render a block.
+ *
+ * @author WebDevStudios
+ *
+ * @param string $block_name The name of the block.
+ * @param array  $args Args for the block.
+ */
+function print_block( $block_name = '', $args = [] ) {
+	if ( ! $block_name ) {
+		return;
+	}
+
+	// extract args.
+	if ( ! empty( $args ) ) {
+		extract( $args ); //phpcs:ignore WordPress.PHP.DontExtract.extract_extract -- We can use it here since we know what to expect on the arguments.
+	}
+
+	require ABS_ROOT_PATH . 'src/blocks/' . $block_name . '/' . $block_name . '.php';
+}

--- a/inc/helpers/print-element.php
+++ b/inc/helpers/print-element.php
@@ -12,8 +12,8 @@ namespace WebDevStudios\abs;
  *
  * @author WebDevStudios
  *
- * @param string $element_name The name of the block.
- * @param array  $args Args for the block.
+ * @param string $element_name The name of the element.
+ * @param array  $args Args for the element.
  */
 function print_element( $element_name = '', $args = [] ) {
 	if ( ! $element_name ) {

--- a/src/blocks/accordion/accordion.php
+++ b/src/blocks/accordion/accordion.php
@@ -7,10 +7,11 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_module;
 use function WebDevStudios\abs\get_acf_fields;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-accordion' ],

--- a/src/blocks/accordion/accordion.php
+++ b/src/blocks/accordion/accordion.php
@@ -16,7 +16,7 @@ use function WebDevStudios\abs\print_module;
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-accordion' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 // Get custom classes for the block and/or for block colors.

--- a/src/blocks/accordion/accordion.php
+++ b/src/blocks/accordion/accordion.php
@@ -17,7 +17,13 @@ $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-accordion' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -30,9 +36,8 @@ endif;
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
-// Pull in the fields from ACF.
-$abs_accordion = get_acf_fields( [ 'accordion_items' ], $block['id'] );
-
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_accordion = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'accordion_items' ], $block['id'] );
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/accordion/accordion.php
+++ b/src/blocks/accordion/accordion.php
@@ -50,7 +50,9 @@ $abs_accordion = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : 
 <?php elseif ( $abs_accordion['accordion_items']['items'] ) : ?>
 	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
-		echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
 
 		print_module( 'accordion', $abs_accordion['accordion_items'] );
 		?>

--- a/src/blocks/accordion/accordion.php
+++ b/src/blocks/accordion/accordion.php
@@ -26,8 +26,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );

--- a/src/blocks/cards-repeater/cards-repeater.php
+++ b/src/blocks/cards-repeater/cards-repeater.php
@@ -7,10 +7,11 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_module;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_acf_fields;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-cards-repeater' ],

--- a/src/blocks/cards-repeater/cards-repeater.php
+++ b/src/blocks/cards-repeater/cards-repeater.php
@@ -17,7 +17,13 @@ $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-cards-repeater' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -30,8 +36,8 @@ endif;
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
-// Pull in the fields from ACF.
-$abs_cards = get_acf_fields( [ 'card' ], $block['id'] );
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_cards = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'card' ], $block['id'] );
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/cards-repeater/cards-repeater.php
+++ b/src/blocks/cards-repeater/cards-repeater.php
@@ -49,7 +49,11 @@ $abs_cards = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_
 	</figure>
 <?php elseif ( $abs_cards['card'] ) : ?>
 	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-		<?php echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />'; ?>
+		<?php
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
+		?>
 		<section class="card-wrap">
 			<?php
 			foreach ( $abs_cards['card'] as $abs_card ) :

--- a/src/blocks/cards-repeater/cards-repeater.php
+++ b/src/blocks/cards-repeater/cards-repeater.php
@@ -16,7 +16,7 @@ use function WebDevStudios\abs\print_module;
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-cards-repeater' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 // Get custom classes for the block and/or for block colors.

--- a/src/blocks/cards-repeater/cards-repeater.php
+++ b/src/blocks/cards-repeater/cards-repeater.php
@@ -26,8 +26,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );

--- a/src/blocks/carousel/carousel.php
+++ b/src/blocks/carousel/carousel.php
@@ -19,7 +19,7 @@ $abs_defaults = [
 	'show_arrows'         => true,
 	'show_pagination'     => true,
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 

--- a/src/blocks/carousel/carousel.php
+++ b/src/blocks/carousel/carousel.php
@@ -52,11 +52,11 @@ if ( ! empty( $block['data']['_is_preview'] ) ) :
 			alt="<?php esc_html_e( 'Preview of the Carousel Block', 'abs' ); ?>"
 		>
 	</figure>
-	<?php
-elseif ( $abs_carousels['slides'] ) :
-	?>
-	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-		<?php echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />'; ?>
+		<?php
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
+		?>
 		<section class="carousel-wrap">
 			<div class="swiper">
 				<ul class="swiper-wrapper carousel-items">

--- a/src/blocks/carousel/carousel.php
+++ b/src/blocks/carousel/carousel.php
@@ -43,15 +43,15 @@ $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 $abs_carousels = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'overlay', 'slides' ], $block['id'] );
 ?>
 
-<?php
-if ( ! empty( $block['data']['_is_preview'] ) ) :
-	?>
+<?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>
 	<figure>
 		<img
 			src="<?php echo esc_url( get_theme_file_uri( 'build/images/block-previews/carousel-preview.jpg' ) ); ?>"
 			alt="<?php esc_html_e( 'Preview of the Carousel Block', 'abs' ); ?>"
 		>
 	</figure>
+<?php elseif ( $abs_carousels['slides'] ) : ?>
+	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
 		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
 			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';

--- a/src/blocks/carousel/carousel.php
+++ b/src/blocks/carousel/carousel.php
@@ -20,8 +20,13 @@ $abs_defaults = [
 	'show_pagination'     => true,
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
 
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -34,8 +39,8 @@ endif;
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
-// Pull in the fields from ACF.
-$abs_carousels = get_acf_fields( [ 'overlay', 'slides' ], $block['id'] );
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_carousels = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'overlay', 'slides' ], $block['id'] );
 ?>
 
 <?php

--- a/src/blocks/carousel/carousel.php
+++ b/src/blocks/carousel/carousel.php
@@ -29,8 +29,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );

--- a/src/blocks/carousel/carousel.php
+++ b/src/blocks/carousel/carousel.php
@@ -7,11 +7,12 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_module;
-use function WebDevStudios\abs\print_element;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_acf_fields;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_element;
+use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', '.wds-block-carousel' ],

--- a/src/blocks/logo-grid/logo-grid.php
+++ b/src/blocks/logo-grid/logo-grid.php
@@ -16,7 +16,7 @@ use function WebDevStudios\abs\print_module;
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-logo-grid' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 // Get custom classes for the block and/or for block colors.

--- a/src/blocks/logo-grid/logo-grid.php
+++ b/src/blocks/logo-grid/logo-grid.php
@@ -7,10 +7,11 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_module;
 use function WebDevStudios\abs\get_acf_fields;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-logo-grid' ],

--- a/src/blocks/logo-grid/logo-grid.php
+++ b/src/blocks/logo-grid/logo-grid.php
@@ -50,7 +50,9 @@ $abs_logo_grid = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : 
 <?php elseif ( $abs_logo_grid['logos'] ) : ?>
 	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
-		echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
 		foreach ( $abs_logo_grid['logos'] as $abs_logo ) :
 			print_module(
 				'figure',

--- a/src/blocks/logo-grid/logo-grid.php
+++ b/src/blocks/logo-grid/logo-grid.php
@@ -17,7 +17,13 @@ $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-logo-grid' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -30,8 +36,8 @@ endif;
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
-// Pull in the fields from ACF.
-$abs_logo_grid = get_acf_fields( [ 'logos' ], $block['id'] );
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_logo_grid = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'logos' ], $block['id'] );
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/logo-grid/logo-grid.php
+++ b/src/blocks/logo-grid/logo-grid.php
@@ -26,8 +26,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );

--- a/src/blocks/quotes/quotes.php
+++ b/src/blocks/quotes/quotes.php
@@ -16,7 +16,7 @@ use function WebDevStudios\abs\print_element;
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-quotes' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 // Get custom classes for the block and/or for block colors.

--- a/src/blocks/quotes/quotes.php
+++ b/src/blocks/quotes/quotes.php
@@ -7,10 +7,11 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_element;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_acf_fields;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_element;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-quotes' ],

--- a/src/blocks/quotes/quotes.php
+++ b/src/blocks/quotes/quotes.php
@@ -49,7 +49,11 @@ $abs_quotes = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get
 	</figure>
 <?php elseif ( $abs_quotes['quotes'] ) : ?>
 	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
-		<?php echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />'; ?>
+		<?php
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
+		?>
 		<?php foreach ( $abs_quotes['quotes'] as $abs_quote ) : ?>
 			<div class="quote">
 				<?php

--- a/src/blocks/quotes/quotes.php
+++ b/src/blocks/quotes/quotes.php
@@ -17,7 +17,13 @@ $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-quotes' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -30,8 +36,8 @@ endif;
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
-// Pull in the fields from ACF.
-$abs_quotes = get_acf_fields( [ 'quotes' ], $block['id'] );
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_quotes = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'quotes' ], $block['id'] );
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/quotes/quotes.php
+++ b/src/blocks/quotes/quotes.php
@@ -12,7 +12,6 @@ use function WebDevStudios\abs\get_block_classes;
 use function WebDevStudios\abs\get_formatted_args;
 use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\print_element;
-
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-quotes' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
@@ -26,8 +25,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );
@@ -38,6 +36,7 @@ $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
 // Pull in the fields from ACF, if we've not pulled them in using print_block().
 $abs_quotes = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'quotes' ], $block['id'] );
+
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/side-by-side/side-by-side.php
+++ b/src/blocks/side-by-side/side-by-side.php
@@ -7,10 +7,11 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_module;
 use function WebDevStudios\abs\get_acf_fields;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', '.wds-block-side-by-side' ],

--- a/src/blocks/side-by-side/side-by-side.php
+++ b/src/blocks/side-by-side/side-by-side.php
@@ -16,7 +16,7 @@ use function WebDevStudios\abs\print_module;
 $abs_defaults = [
 	'class'               => [ 'wds-block', '.wds-block-side-by-side' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 // Get custom classes for the block and/or for block colors.

--- a/src/blocks/side-by-side/side-by-side.php
+++ b/src/blocks/side-by-side/side-by-side.php
@@ -17,7 +17,13 @@ $abs_defaults = [
 	'class'               => [ 'wds-block', '.wds-block-side-by-side' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -27,13 +33,13 @@ if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );
 endif;
 
-// Pull in the fields from ACF.
-$abs_side_by_side = get_acf_fields( [ 'column_order', 'image', 'card' ], $block['id'] );
-
 $abs_defaults['class'][] = $abs_side_by_side['column_order'];
 
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
+
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_side_by_side = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'column_order', 'image', 'card' ], $block['id'] );
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/side-by-side/side-by-side.php
+++ b/src/blocks/side-by-side/side-by-side.php
@@ -14,7 +14,7 @@ use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
-	'class'               => [ 'wds-block', '.wds-block-side-by-side' ],
+	'class'               => [ 'wds-block', 'wds-block-side-by-side' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 	'fields'              => [], // Fields passed via the print_block() function.
@@ -52,7 +52,9 @@ $abs_side_by_side = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields']
 <?php else : ?>
 	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
-		echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
 
 		print_module(
 			'figure',

--- a/src/blocks/side-by-side/side-by-side.php
+++ b/src/blocks/side-by-side/side-by-side.php
@@ -26,8 +26,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );

--- a/src/blocks/tabs/tabs.php
+++ b/src/blocks/tabs/tabs.php
@@ -7,10 +7,11 @@
  * @package abs
  */
 
-use function WebDevStudios\abs\print_module;
 use function WebDevStudios\abs\get_acf_fields;
-use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_module;
 
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-tabs' ],

--- a/src/blocks/tabs/tabs.php
+++ b/src/blocks/tabs/tabs.php
@@ -50,7 +50,9 @@ $abs_tabs = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_a
 <?php elseif ( $abs_tabs['tab_items']['items'] ) : ?>
 	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
 		<?php
-		echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
 
 		print_module( 'tabs', $abs_tabs['tab_items'] );
 		?>

--- a/src/blocks/tabs/tabs.php
+++ b/src/blocks/tabs/tabs.php
@@ -17,7 +17,13 @@ $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-tabs' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
 	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
 ];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
 
 // Get custom classes for the block and/or for block colors.
 $abs_block_classes = [];
@@ -30,8 +36,8 @@ endif;
 // Set up element attributes.
 $abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
 
-// Pull in the fields from ACF.
-$abs_tabs = get_acf_fields( [ 'tab_items' ], $block['id'] );
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_tabs = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'tab_items' ], $block['id'] );
 ?>
 
 <?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>

--- a/src/blocks/tabs/tabs.php
+++ b/src/blocks/tabs/tabs.php
@@ -16,7 +16,7 @@ use function WebDevStudios\abs\print_module;
 $abs_defaults = [
 	'class'               => [ 'wds-block', 'wds-block-tabs' ],
 	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
-	'id'                  => ! empty( $block['anchor'] ) ? $block['anchor'] : '',
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
 ];
 
 // Get custom classes for the block and/or for block colors.

--- a/src/blocks/tabs/tabs.php
+++ b/src/blocks/tabs/tabs.php
@@ -26,8 +26,7 @@ if ( ! empty( $args ) ) :
 endif;
 
 // Get custom classes for the block and/or for block colors.
-$abs_block_classes = [];
-$abs_block_classes = get_block_classes( $block );
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : [];
 
 if ( ! empty( $abs_block_classes ) ) :
 	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );

--- a/src/modules/card.php
+++ b/src/modules/card.php
@@ -84,7 +84,14 @@ $abs_atts = get_formatted_atts( [ 'class' ], $abs_args );
 
 	// Button.
 	if ( $abs_args['button'] ) :
-		print_element( 'button', $abs_args['button'] );
+		print_element(
+			'button',
+			[
+				'title'  => $abs_args['button']['title'],
+				'href'   => $abs_args['button']['url'],
+				'target' => $abs_args['button']['target'],
+			]
+		);
 	endif;
 	?>
 </div>


### PR DESCRIPTION
Closes #WENG-239

### DESCRIPTION ###
- Created the function file
- troubleshot the implementation in an accompanying template part; added example code to the function file `print_block.php`
- Updated the current blocks to allow for handling of fields 

### SCREENSHOTS ###
![image](https://user-images.githubusercontent.com/102187271/195669336-4d41e78c-18cb-41c0-a6cb-d113175b0bb7.png)

### STEPS TO VERIFY ###
* Pull the code locally
* Use the documentation to use a `print_block()` function inside a template part
* Verify that the block renders with the passed field data
