### PR TITLE
Add Call to Action block

### DIFF
--- a/acf-json/group_6346c08d323e8.json
+++ b/acf-json/group_6346c08d323e8.json
@@ -1,0 +1,128 @@
+{
+    "key": "group_6346c08d323e8",
+    "title": "Block: Call to Action",
+    "fields": [
+        {
+            "key": "field_6346c08d2eb6f",
+            "label": "Eyebrow",
+            "name": "eyebrow",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_6346c135fd3e5",
+            "label": "Heading",
+            "name": "heading",
+            "type": "text",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "placeholder": "",
+            "prepend": "",
+            "append": ""
+        },
+        {
+            "key": "field_6346c16186509",
+            "label": "Content",
+            "name": "content",
+            "type": "textarea",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "default_value": "",
+            "maxlength": "",
+            "rows": 3,
+            "placeholder": "",
+            "new_lines": "wpautop"
+        },
+        {
+            "key": "field_6346c13efd3e6",
+            "label": "Button",
+            "name": "button_args",
+            "type": "clone",
+            "instructions": "",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "clone": [
+                "group_59416d894b7c7"
+            ],
+            "display": "seamless",
+            "layout": "block",
+            "prefix_label": 0,
+            "prefix_name": 0
+        },
+        {
+            "key": "field_6346ce226e894",
+            "label": "Layout",
+            "name": "layout",
+            "type": "radio",
+            "instructions": "Left-aligned or Right-aligned content. The button will be on the opposite side of the content.\r\nCenter will stack and center-align the content.",
+            "required": 0,
+            "conditional_logic": 0,
+            "wrapper": {
+                "width": "",
+                "class": "",
+                "id": ""
+            },
+            "choices": {
+                "left": "Left",
+                "right": "Right",
+                "center": "Center"
+            },
+            "default_value": "left",
+            "return_format": "value",
+            "allow_null": 0,
+            "other_choice": 0,
+            "layout": "vertical",
+            "save_other_choice": 0
+        }
+    ],
+    "location": [
+        [
+            {
+                "param": "block",
+                "operator": "==",
+                "value": "abs\/call-to-action"
+            }
+        ]
+    ],
+    "menu_order": 0,
+    "position": "normal",
+    "style": "default",
+    "label_placement": "top",
+    "instruction_placement": "label",
+    "hide_on_screen": "",
+    "active": true,
+    "description": "",
+    "show_in_rest": 0,
+    "modified": 1665587244
+}

--- a/src/blocks/call-to-action/block.json
+++ b/src/blocks/call-to-action/block.json
@@ -1,0 +1,32 @@
+{
+	"name": "abs/call-to-action",
+	"title": "Call to Action",
+	"description": "",
+	"editorStyle": "file:./editor.css",
+	"editorScript": "file:./editor.js",
+	"style": "file:./style-script.css",
+	"script": "file:./script.js",
+	"category": "WDS",
+	"icon": "megaphone",
+	"apiVersion": 2,
+	"keywords": [ "call-to-action", "block" ],
+	"acf": {
+		"mode": "auto",
+		"renderTemplate": "call-to-action.php"
+	},
+	"supports": {
+		"align": false,
+		"anchor": true,
+		"color": true,
+		"customClassName": true,
+		"jsx": true
+	},
+	"example": {
+		"attributes": {
+			"mode": "preview",
+			"data": {
+				"_is_preview": "true"
+			}
+		}
+	}
+}

--- a/src/blocks/call-to-action/call-to-action.php
+++ b/src/blocks/call-to-action/call-to-action.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * BLOCK - Renders a Call to Action block
+ *
+ * @link https://developer.wordpress.org/block-editor/
+ *
+ * @package abs
+ */
+
+use function WebDevStudios\abs\get_acf_fields;
+use function WebDevStudios\abs\get_block_classes;
+use function WebDevStudios\abs\get_formatted_args;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\print_module;
+
+$abs_defaults = [
+	'class'               => [ 'wds-block', 'wds-block-call-to-action' ],
+	'allowed_innerblocks' => [ 'core/heading', 'core/paragraph' ],
+	'id'                  => ( isset( $block ) && ! empty( $block['anchor'] ) ) ? $block['anchor'] : '',
+	'fields'              => [], // Fields passed via the print_block() function.
+];
+
+// Parse the $args if we're rendering this with print_block() from a theme.
+if ( ! empty( $args ) ) :
+	$abs_defaults = get_formatted_args( $args, $abs_defaults );
+endif;
+
+// Get custom classes for the block and/or for block colors.
+$abs_block_classes = [];
+$abs_block_classes = isset( $block ) ? get_block_classes( $block ) : '';
+
+if ( ! empty( $abs_block_classes ) ) :
+	$abs_defaults['class'] = array_merge( $abs_defaults['class'], $abs_block_classes );
+endif;
+
+// Pull in the fields from ACF, if we've not pulled them in using print_block().
+$abs_call_to_action = ! empty( $abs_defaults['fields'] ) ? $abs_defaults['fields'] : get_acf_fields( [ 'eyebrow', 'heading', 'content', 'button_args', 'layout' ], $block['id'] );
+
+// Set up element attributes.
+$abs_atts = get_formatted_atts( [ 'class', 'id' ], $abs_defaults );
+?>
+
+<?php if ( ! empty( $block['data']['_is_preview'] ) ) : ?>
+	<figure>
+		<img
+			src="<?php echo esc_url( get_theme_file_uri( 'build/images/block-previews/call-to-action-preview.jpg' ) ); ?>"
+			alt="<?php esc_html_e( 'Preview of the Call to Action Block', 'abs' ); ?>"
+		>
+	</figure>
+<?php else : ?>
+	<section <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+		<?php
+		if ( ! empty( $abs_defaults['allowed_innerblocks'] ) ) :
+			echo '<InnerBlocks allowedBlocks="' . esc_attr( wp_json_encode( $abs_defaults['allowed_innerblocks'] ) ) . '" />';
+		endif;
+
+		print_module( 'call-to-action-' . esc_attr( $abs_call_to_action['layout'] ), $abs_call_to_action );
+		?>
+	</section>
+<?php endif; ?>

--- a/src/blocks/call-to-action/editor.js
+++ b/src/blocks/call-to-action/editor.js
@@ -1,0 +1,3 @@
+import './editor.scss';
+
+// Editor JS here.

--- a/src/blocks/call-to-action/editor.scss
+++ b/src/blocks/call-to-action/editor.scss
@@ -1,0 +1,1 @@
+// Editor styles.

--- a/src/blocks/call-to-action/script.js
+++ b/src/blocks/call-to-action/script.js
@@ -1,0 +1,9 @@
+/**
+ * Block script.
+ *
+ * @package
+ * @since ??
+ */
+import './style.scss';
+
+// add JS here.

--- a/src/blocks/call-to-action/style.scss
+++ b/src/blocks/call-to-action/style.scss
@@ -1,0 +1,1 @@
+// Frontend styles.

--- a/src/blocks/call-to-action/tailwind.config.js
+++ b/src/blocks/call-to-action/tailwind.config.js
@@ -1,0 +1,17 @@
+const blockName = 'call-to-action';
+const fs = require( 'fs' );
+
+const directoryFiles = [
+	`./src/blocks/${ blockName }/*.php`,
+	`./src/blocks/${ blockName }/*.scss`,
+	`./src/blocks/${ blockName }/*.js`,
+];
+
+module.exports = {
+	presets: [
+		fs.existsSync( global.themePreset )
+			? require( global.themePreset )
+			: '',
+	],
+	content: directoryFiles,
+};

--- a/src/modules/call-to-action-center.php
+++ b/src/modules/call-to-action-center.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * MODULE - Call to Action
+ *
+ * Modules are analagous to 'Molecules' in Brad Frost's Atomic Design Methodology.
+ *
+ * @link https://atomicdesign.bradfrost.com/chapter-2/#molecules
+ *
+ * @package abs
+ */
+
+use function WebDevStudios\abs\print_element;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\get_formatted_args;
+
+$abs_defaults = [
+	'class'       => [ 'wds-module', 'wds-module-cta' ],
+	'eyebrow'     => false,
+	'heading'     => false,
+	'content'     => false,
+	'button_args' => false,
+];
+
+$abs_args = get_formatted_args( $args, $abs_defaults );
+
+// Set up element attributes.
+$abs_atts = get_formatted_atts( [ 'class' ], $abs_args );
+
+?>
+<div <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php
+	// Eyebrow.
+	if ( $abs_args['eyebrow'] ) :
+		print_element(
+			'eyebrow',
+			[
+				'text' => $abs_args['eyebrow'],
+			]
+		);
+	endif;
+
+	// Heading.
+	if ( $abs_args['heading'] ) :
+		print_element(
+			'heading',
+			[
+				'text' => $abs_args['heading'],
+			]
+		);
+	endif;
+
+	// Content.
+	if ( $abs_args['content'] ) :
+		print_element(
+			'content',
+			[
+				'content' => $abs_args['content'],
+			]
+		);
+	endif;
+
+	// Button.
+	if ( $abs_args['button_args'] ) :
+		// Simplify this array.
+		$abs_button_args = $abs_args['button_args']['button'];
+
+		print_element(
+			'button',
+			[
+				'title'  => $abs_button_args['title'],
+				'href'   => $abs_button_args['url'],
+				'target' => $abs_button_args['target'],
+			]
+		);
+	endif;
+	?>
+</div>

--- a/src/modules/call-to-action-left.php
+++ b/src/modules/call-to-action-left.php
@@ -14,10 +14,11 @@ use function WebDevStudios\abs\get_formatted_atts;
 use function WebDevStudios\abs\get_formatted_args;
 
 $abs_defaults = [
-	'class'        => [ 'wds-module', 'wds-module-cta' ],
-	'eyebrow'      => false,
-	'heading_args' => false,
-	'button'       => false,
+	'class'       => [ 'wds-module', 'wds-module-cta' ],
+	'eyebrow'     => false,
+	'heading'     => false,
+	'content'     => false,
+	'button_args' => false,
 ];
 
 $abs_args = get_formatted_args( $args, $abs_defaults );
@@ -27,6 +28,7 @@ $abs_atts = get_formatted_atts( [ 'class' ], $abs_args );
 
 ?>
 <div <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<div class="left-content">
 	<?php
 	// Eyebrow.
 	if ( $abs_args['eyebrow'] ) :
@@ -39,15 +41,39 @@ $abs_atts = get_formatted_atts( [ 'class' ], $abs_args );
 	endif;
 
 	// Heading.
-	if ( $abs_args['heading_args'] ) :
-		print_element( 'heading', $abs_args['heading_args'] );
+	if ( $abs_args['heading'] ) :
+		print_element(
+			'heading',
+			[
+				'text' => $abs_args['heading'],
+			]
+		);
 	endif;
 
+	// Content.
+	if ( $abs_args['content'] ) :
+		print_element(
+			'content',
+			[
+				'content' => $abs_args['content'],
+			]
+		);
+	endif;
+	?>
+	</div>
+	<?php
 	// Button.
-	if ( $abs_args['button'] ) :
+	if ( $abs_args['button_args'] ) :
+		// Simplify this array.
+		$abs_button_args = $abs_args['button_args']['button'];
+
 		print_element(
 			'button',
-			$abs_args['button']
+			[
+				'title'  => $abs_button_args['title'],
+				'href'   => $abs_button_args['url'],
+				'target' => $abs_button_args['target'],
+			]
 		);
 	endif;
 	?>

--- a/src/modules/call-to-action-right.php
+++ b/src/modules/call-to-action-right.php
@@ -1,0 +1,80 @@
+<?php
+/**
+ * MODULE - Call to Action
+ *
+ * Modules are analagous to 'Molecules' in Brad Frost's Atomic Design Methodology.
+ *
+ * @link https://atomicdesign.bradfrost.com/chapter-2/#molecules
+ *
+ * @package abs
+ */
+
+use function WebDevStudios\abs\print_element;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\get_formatted_args;
+
+$abs_defaults = [
+	'class'       => [ 'wds-module', 'wds-module-cta' ],
+	'eyebrow'     => false,
+	'heading'     => false,
+	'content'     => false,
+	'button_args' => false,
+];
+
+$abs_args = get_formatted_args( $args, $abs_defaults );
+
+// Set up element attributes.
+$abs_atts = get_formatted_atts( [ 'class' ], $abs_args );
+
+?>
+<div <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<?php
+	// Button.
+	if ( $abs_args['button_args'] ) :
+		// Simplify this array.
+		$abs_button_args = $abs_args['button_args']['button'];
+
+		print_element(
+			'button',
+			[
+				'title'  => $abs_button_args['title'],
+				'href'   => $abs_button_args['url'],
+				'target' => $abs_button_args['target'],
+			]
+		);
+	endif;
+	?>
+	<div class="right-content">
+		<?php
+		// Eyebrow.
+		if ( $abs_args['eyebrow'] ) :
+			print_element(
+				'eyebrow',
+				[
+					'text' => $abs_args['eyebrow'],
+				]
+			);
+		endif;
+
+		// Heading.
+		if ( $abs_args['heading'] ) :
+			print_element(
+				'heading',
+				[
+					'text' => $abs_args['heading'],
+				]
+			);
+		endif;
+
+		// Content.
+		if ( $abs_args['content'] ) :
+			print_element(
+				'content',
+				[
+					'content' => $abs_args['content'],
+				]
+			);
+		endif;
+		?>
+	</div>
+</div>


### PR DESCRIPTION
Closes #WENG-240

### DESCRIPTION ###
- Creates a Call to Action block
- Accepts fields from an external function call via `print_block()`
- has layout options for right/left/center display 
- does not style the block in any way

### SCREENSHOTS ###
![image](https://user-images.githubusercontent.com/102187271/195677636-7896d5c0-a339-4a16-8276-0d2db0dfbdd2.png)

### STEPS TO VERIFY ###
* pull the branch
* use the block
* verify that it works