### PR TITLE
Fixed :: Keyword param not working for WP CLI command

### DIFF
--- a/wpcli/class-blocks-scaffold.php
+++ b/wpcli/class-blocks-scaffold.php
@@ -178,12 +178,14 @@ class Blocks_Scaffold {
 					'{{title}}',
 					'{{description}}',
 					'{{icon}}',
+					'{{keyword}}',
 				],
 				[
 					$this->name,
 					$args['title'],
 					$args['desc'],
 					$args['icon'],
+					$args['keyword'],
 				],
 				$content
 			);


### PR DESCRIPTION


### DESCRIPTION ###
- Fixes the issues with wpcli scaffolded blocks not using the keyword param properly. 
- ref: https://webdevstudios.atlassian.net/browse/WENG-250