### PR TITLE
Feature/weng 251 breadcrumbs module

### DIFF
--- a/assets/global-styles/frontend-styles.scss
+++ b/assets/global-styles/frontend-styles.scss
@@ -1,5 +1,5 @@
 //----------------------------------------
-// Global block styles, Frontend.
+// Global Block styles, Frontend.
 //----------------------------------------
 .wds-block {
 	@apply my-64;
@@ -11,6 +11,29 @@
 
 		&:empty {
 			@apply hidden;
+		}
+	}
+}
+
+//----------------------------------------
+// Global Module styles, Frontend.
+//----------------------------------------
+.wds-module-breadcrumbs {
+	@apply my-16;
+
+	ol {
+		@apply inline-flex;
+
+		li {
+			@apply inline-flex;
+
+			.breadcrumbs-divider {
+				@apply mx-8;
+			}
+
+			&:last-child > a {
+				@apply text-gray-500 no-underline;
+			}
 		}
 	}
 }

--- a/assets/global-styles/frontend-styles.scss
+++ b/assets/global-styles/frontend-styles.scss
@@ -31,7 +31,7 @@
 				@apply text-gray-500 mx-8;
 			}
 
-			.breadcrumbs-current-page > a {
+			.breadcrumbs-current-page {
 				@apply text-gray-500 no-underline;
 			}
 		}

--- a/assets/global-styles/frontend-styles.scss
+++ b/assets/global-styles/frontend-styles.scss
@@ -28,10 +28,10 @@
 			@apply inline-flex;
 
 			.breadcrumbs-divider {
-				@apply mx-8;
+				@apply text-gray-500 mx-8;
 			}
 
-			&:last-child > a {
+			.breadcrumbs-current-page > a {
 				@apply text-gray-500 no-underline;
 			}
 		}

--- a/src/elements/button.php
+++ b/src/elements/button.php
@@ -28,6 +28,7 @@ $abs_defaults = [
 		'disabled' => false,
 		'expanded' => false,
 		'label'    => false,
+		'current'  => '',
 	],
 ];
 

--- a/src/modules/breadcrumbs.php
+++ b/src/modules/breadcrumbs.php
@@ -11,12 +11,12 @@
 /**
  * Expected shape of the links array.
  * [
- *  'title' => 'url' (relative),
- *  'title' => 'url' (relative),
+ *  post_ID,
+ *  post_ID,
  * ]
  *
  * These will render like:
- * Home / Link 1 / Link 2
+ * Home / Link 1 / Link 2 / Current Page
  *
  * The home icon will display if 'display_home_icon' is true, otherwise 'Home' will be displayed as text.
  * The current page will display if 'display_current_page' is true.

--- a/src/modules/breadcrumbs.php
+++ b/src/modules/breadcrumbs.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * MODULE - Breadcrumbs.
+ *
+ * @link https://developer.wordpress.org/block-editor/
+ * @link Accessibility considerations: https://www.aditus.io/patterns/breadcrumbs/
+ *
+ * @package abs
+ */
+
+/**
+ * Expected shape of the links array.
+ * [
+ *  'title' => 'url' (relative),
+ *  'title' => 'url' (relative),
+ * ]
+ *
+ * These will render like:
+ * Home / Link 1 / Link 2
+ *
+ * The home icon will display if 'display_home_icon' is true, otherwise 'Home' will be displayed as text.
+ * The current page will display if 'display_current_page' is true.
+ */
+
+use function WebDevStudios\abs\print_element;
+use function WebDevStudios\abs\get_formatted_atts;
+use function WebDevStudios\abs\get_formatted_args;
+
+$abs_defaults = [
+	'class'                => [ 'wds-module', 'wds-module-breadcrumbs' ],
+	'display_current_page' => true,
+	'display_home_icon'    => true,
+	'divider'              => '/', // This should be a UTF-8 icon or text character, such as ▶ (https://utf8-icons.com).
+	'links'                => [],
+	'aria'                 => [
+		'label' => 'breadcrumbs',
+	],
+];
+
+$abs_args = get_formatted_args( $args, $abs_defaults );
+
+// Set up element attributes.
+$abs_atts = get_formatted_atts( [ 'class', 'aria' ], $abs_args );
+?>
+
+<nav <?php echo $abs_atts; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>>
+	<ol>
+		<li>
+			<a href="/">
+			<?php if ( $abs_args['display_home_icon'] ) : ?>
+				<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-tabler icon-tabler-home" width="24" height="24" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" fill="none" stroke-linecap="round" stroke-linejoin="round">
+					<path stroke="none" d="M0 0h24v24H0z" fill="none"></path>
+					<polyline points="5 12 3 12 12 3 21 12 19 12"></polyline>
+					<path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7"></path>
+					<path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6"></path>
+				</svg>
+			<?php else : ?>
+				<span class="home-link"><?php esc_html_e( 'Home', 'abs' ); ?></span>
+			<?php endif; ?>
+			</a>
+			<span class="breadcrumbs-divider"><?php echo esc_html( $abs_args['divider'] ); ?></span>
+		</li>
+
+		<?php if ( ! empty( $abs_args['links'] ) ) : ?>
+			<?php foreach ( $abs_args['links'] as $abs_page_id ) : ?>
+				<li>
+					<?php
+					print_element(
+						'button',
+						[
+							'title' => get_the_title( $abs_page_id ),
+							'url'   => get_the_permalink( $abs_page_id ),
+						]
+					);
+					?>
+					<?php if ( end( $abs_args['links'] ) !== $abs_page_id ) : ?>
+					<span class="breadcrumbs-divider"><?php echo esc_html( $abs_args['divider'] ); ?></span>
+					<?php endif; ?>
+				</li>
+			<?php endforeach; ?>
+		<?php endif; ?>
+
+		<?php if ( $abs_args['display_current_page'] ) : ?>
+			<li>
+				<?php if ( ! empty( $abs_args['links'] ) ) : ?>
+					<span class="breadcrumbs-divider"><?php echo esc_html( $abs_args['divider'] ); ?></span>
+				<?php endif; ?>
+				<?php
+				print_element(
+					'button',
+					[
+						'title' => get_the_title(),
+						'url'   => get_the_permalink(),
+						'aria'  => [
+							'current' => 'page',
+						],
+					]
+				);
+				?>
+			</li>
+		<?php endif; ?>
+	</ol>
+</nav>

--- a/src/modules/breadcrumbs.php
+++ b/src/modules/breadcrumbs.php
@@ -91,6 +91,7 @@ $abs_atts = get_formatted_atts( [ 'class', 'aria' ], $abs_args );
 					[
 						'title' => get_the_title(),
 						'url'   => get_the_permalink(),
+						'class' => 'breadcrumbs-current-page',
 						'aria'  => [
 							'current' => 'page',
 						],


### PR DESCRIPTION
Closes #WENG-251

### DESCRIPTION ###
- Created a breadcrumbs module
- Accepts the following params to customize display:
  - 'class'                => [ 'wds-module', 'wds-module-breadcrumbs' ], `Classes to use on parent`
  - 'display_current_page' => true, `// Displays or hides current page`
  - 'display_home_icon'    => true, `// Displays home icon or 'Home'`
  - 'divider'              => '/', `// This should be a UTF-8 icon, html entity, or text character, such as \ or &gt; or ▶ (https://utf8-icons.com).`
  - 'links'                => [], `// Accepts an array of page IDs. Usually generated by get_post_ancestors( get_the_ID() ) or similar`

### SCREENSHOTS ###
![image](https://user-images.githubusercontent.com/18194487/199810313-56dbfd5c-42aa-4b95-87c3-e61523f71e05.png)


### OTHER ###
- [X] Is this issue accessible? (Section 508/WCAG 2.0AA) 
  - Yes! Aria current is being rendered on the current page, it is using an ordered list for easy hierarchy and the nav has an aria label 
- [X] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)

### STEPS TO VERIFY ###
Add to the top of the template part where you want to render the breadcrumbs:
`use function WebDevStudios\abs\print_module;`

Add to the body of the template part (ie: `content-page.php`, inside `.entry-header`) like so:
```
<?php
$wd_s_page_ancestors = get_post_ancestors( get_the_ID() );
if ( function_exists( 'WebDevStudios\abs\print_module' ) ) :
	print_module(
		'breadcrumbs',
		[
			'display_current_page' => true,
			'display_home_icon'    => true,
			'divider'              => '&gt;',
			'links'                  => array_reverse( $wd_s_page_ancestors ), // get_post_ancestors() returns from top down, so let's reverse it.
		]
	);
endif;
?>
