### PR TITLE
Tweak installers requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
 		}
 	},
 	"require": {
-		"composer/installers": "^2.0.0"
+		"composer/installers": "^1.5 || ^2.0"
 	},
 	"require-dev": {
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe5e3d7ff9db36bad3ad98f1862de2f0",
+    "content-hash": "d8dbeb7c3fae5fba7bf565f8a0faa7c7",
     "packages": [
         {
             "name": "composer/installers",


### PR DESCRIPTION
Closes #71 

### DESCRIPTION ###
- Changed the `composer/installers` requirement to allow backwards compatibility

### SCREENSHOTS ###
![Screenshot from 2022-11-16 19-53-53](https://user-images.githubusercontent.com/630830/202335142-6b06a82e-cec8-423e-bab5-d0d13c557a6c.png)


### OTHER ###
- [x] Is this issue accessible? (Section 508/WCAG 2.0AA)
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)
- [x] Does this pass CBT?

### STEPS TO VERIFY ###
How do we test this? `composer install` in this project or `composer require webdevstudios/wds-acf-blocks:dev-feature/81-composer-installers` in a project
