### PR TITLE
Configurable Card heading level

### DIFF
--- a/src/modules/card.php
+++ b/src/modules/card.php
@@ -18,6 +18,7 @@ $abs_defaults = [
 	'class'         => [ 'wds-module', 'wds-module-card' ],
 	'eyebrow'       => false,
 	'heading'       => false,
+	'heading_level' => 2,
 	'content'       => false,
 	'button'        => false,
 	'attachment_id' => false,
@@ -61,7 +62,7 @@ $abs_atts = get_formatted_atts( [ 'class' ], $abs_args );
 			'heading',
 			[
 				'text'  => $abs_args['heading'],
-				'level' => 2,
+				'level' => $abs_args['heading_level'],
 			]
 		);
 	endif;


### PR DESCRIPTION
### DESCRIPTION ###
- Add a heading_level parameter to increase reusability, defaults to previous level 2

### OTHER ###
- [x] Does this issue pass all the linting? (PHPCS, ESLint, SassLint)

### STEPS TO VERIFY ###
How do we test this?
1. Call print_module() with or without a 'heading_level' parameter
```
print_module(
	'card',
	[
		'src'           => get_the_post_thumbnail_url( $scb_example_post->ID ),
		'eyebrow'       => esc_html( get_term( yoast_get_primary_term_id( 'category', $scb_example_post->ID ) )->name ),
		'heading'       => esc_html( $scb_example_post->post_title ),
		'heading_level' => 3,
	]
);
```
