### PR TITLE
env.js - Use a relative path

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ Start by copying the file `env-example.json` and name it `env.json`. Inside that
 
 ```json
 {
-	"tailwindPreset": "/Users/yourusername/Sites/yourproject/app/public/wp-content/themes/your-wd_s-theme/wds.preset.js"
+	"tailwindPreset": "../../themes/your-wd_s-theme/wds.preset.js"
 }
 ```
 

--- a/env-example.json
+++ b/env-example.json
@@ -1,3 +1,3 @@
 {
-	"tailwindPreset": "/Users/yourusername/Sites/yourproject/app/public/wp-content/themes/your-wd_s-theme/wds.preset.js"
+	"tailwindPreset": "../../themes/your-wd_s-theme/wds.preset.js"
 }


### PR DESCRIPTION
### DESCRIPTION ###
Using a relative path prevents situations where the users path includes `/Local Sites/`. 
Examples where this was an issue:
- https://webdevstudios.slack.com/archives/C3B5387NC/p1676554366199569
- https://webdevstudios.slack.com/archives/C3B5387NC/p1678317268241539

### STEPS TO VERIFY ###
How do we test this?
- Try changing the path on an existing install